### PR TITLE
Replace int by uint64_t on setNextTick definition, for compiling on 3…

### DIFF
--- a/src/midilfo.cpp
+++ b/src/midilfo.cpp
@@ -605,7 +605,7 @@ void MidiLfo::applyPendingParChanges()
     needsGUIUpdate = true;
 }
 
-void MidiLfo::setNextTick(int tick)
+void MidiLfo::setNextTick(uint64_t tick)
 {
     int tickres = TPQN/res;
     int pos = (tick/tickres) % nPoints;

--- a/src/midiseq.cpp
+++ b/src/midiseq.cpp
@@ -484,7 +484,7 @@ void MidiSeq::applyPendingParChanges()
 
 }
 
-void MidiSeq::setNextTick(int tick)
+void MidiSeq::setNextTick(uint64_t tick)
 {
     int tickres = TPQN/res;
     int pos = (tick/tickres) % nPoints;


### PR DESCRIPTION
…2 bit platforms (ARM and others).